### PR TITLE
Fix nullable property with only one oneOf ref

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -746,6 +746,9 @@ public class OpenAPINormalizer {
                     }
                     return (Schema) oneOfSchemas.get(0);
                 }
+            } else if(Boolean.TRUE.equals(schema.getNullable()) && oneOfSchemas.size() == 1) {
+                ((Schema) oneOfSchemas.get(0)).setNullable(true);
+                return (Schema) oneOfSchemas.get(0);
             }
         }
 


### PR DESCRIPTION
Support des nullable de type

```
      properties:
        description:
          oneOf:
            -
              $ref: '#/components/schemas/fieldValue.LocalizedString'
          nullable: true
```