### PR TITLE
CRM-25328: Fix model deepObject serialization for PHP

### DIFF
--- a/modules/openapi-generator-cli/pom.xml
+++ b/modules/openapi-generator-cli/pom.xml
@@ -4,7 +4,7 @@
         <groupId>com.equisoft.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.7.0-equisoft2-SNAPSHOT</version>
+        <version>7.7.0-equisoft3-SNAPSHOT</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/modules/openapi-generator-core/pom.xml
+++ b/modules/openapi-generator-core/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>openapi-generator-project</artifactId>
     <groupId>com.equisoft.openapitools</groupId>
     <!-- RELEASE_VERSION -->
-    <version>7.7.0-equisoft2-SNAPSHOT</version>
+    <version>7.7.0-equisoft3-SNAPSHOT</version>
     <!-- /RELEASE_VERSION -->
     <relativePath>../../pom.xml</relativePath>
   </parent>

--- a/modules/openapi-generator-gradle-plugin/gradle.properties
+++ b/modules/openapi-generator-gradle-plugin/gradle.properties
@@ -1,5 +1,5 @@
 # RELEASE_VERSION
-openApiGeneratorVersion=7.7.0-equisoft2-SNAPSHOT
+openApiGeneratorVersion=7.7.0-equisoft3-SNAPSHOT
 # /RELEASE_VERSION
 
 # BEGIN placeholders

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -4,7 +4,7 @@
         <groupId>com.equisoft.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.7.0-equisoft2-SNAPSHOT</version>
+        <version>7.7.0-equisoft3-SNAPSHOT</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/modules/openapi-generator-maven-plugin/pom.xml
+++ b/modules/openapi-generator-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
         <groupId>com.equisoft.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.7.0-equisoft2-SNAPSHOT</version>
+        <version>7.7.0-equisoft3-SNAPSHOT</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -4,7 +4,7 @@
         <groupId>com.equisoft.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.7.0-equisoft2-SNAPSHOT</version>
+        <version>7.7.0-equisoft3-SNAPSHOT</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -4,7 +4,7 @@
         <groupId>com.equisoft.openapitools</groupId>
         <artifactId>openapi-generator-project</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>7.7.0-equisoft2-SNAPSHOT</version>
+        <version>7.7.0-equisoft3-SNAPSHOT</version>
         <!-- /RELEASE_VERSION -->
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -21,6 +21,7 @@ namespace {{invokerPackage}};
 
 use GuzzleHttp\Psr7\Utils;
 use {{modelPackage}}\ModelInterface;
+use JsonSerializable;
 
 /**
  * ObjectSerializer Class Doc Comment
@@ -231,7 +232,11 @@ class ObjectSerializer
         }
 
         $query = [];
-        $value = (in_array($openApiType, ['object', 'array'], true)) ? (array)$value : $value;
+        // Models are cast to arrays using json encode/decode to properly sanitize
+        // values and recursively handle nested objects
+        if (in_array($openApiType, ['object', 'array'], true)) {
+            $value = ($value instanceof JsonSerializable) ? json_decode(json_encode($value), true) : (array)$value;
+        }
 
         // since \GuzzleHttp\Psr7\Query::build fails with nested arrays
         // need to flatten array first

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
     <name>openapi-generator-project</name>
     <!-- RELEASE_VERSION -->
-    <version>7.7.0-equisoft2-SNAPSHOT</version>
+    <version>7.7.0-equisoft3-SNAPSHOT</version>
     <!-- /RELEASE_VERSION -->
     <url>https://github.com/openapitools/openapi-generator</url>
     <scm>


### PR DESCRIPTION
CRM-25328

Dans le cadre de la correction pour retirer le body de certaines requêtes GET du SDK PHP, l'alternative est de passer les paramètres dans un query parameter au format `deepObject`.

Cependant, l'implémentation actuelle en PHP utilisait un simple cast `(array)`, ce qui ramenait la structure interne des modèles dans l'array de paramètres. En utilisant un encode/decode json, on fait intervenir la serialization prévue pour les modèles (ils implémentent déjà l'interface `JsonSerializable`).